### PR TITLE
LogWindow sometimes obscured.  Some samples added to .organ file with incorrect path.  Wave tremulant addition tweak.

### DIFF
--- a/src/Divisional.cpp
+++ b/src/Divisional.cpp
@@ -146,7 +146,7 @@ void Divisional::read(wxFileConfig *cfg, bool usingOldPanelFormat, Manual *ownin
 					}
 				} else {
 					wxLogError("%s value %s is out of range for divisional '%s' since manual '%s' only lists %u tremulants!", tremNbr, tremId, name, m_owningManual->getName(), m_owningManual->getNumberOfTremulants());
-					::wxGetApp().m_frame->GetLogWindow()->Show(true);
+					SHOWLOGWINDOW;
 				}
 			}
 		}
@@ -168,7 +168,7 @@ void Divisional::read(wxFileConfig *cfg, bool usingOldPanelFormat, Manual *ownin
 					}
 				} else {
 					wxLogError("%s value %s is out of range for divisional '%s' since manual '%s' only lists %u switches!", swNbr, swId, name, m_owningManual->getName(), m_owningManual->getNumberOfGoSwitches());
-					::wxGetApp().m_frame->GetLogWindow()->Show(true);
+					SHOWLOGWINDOW;
 				}
 			}
 		}

--- a/src/Drawstop.cpp
+++ b/src/Drawstop.cpp
@@ -62,7 +62,7 @@ void Drawstop::write(wxTextFile *outFile) {
 		// Issue a warning if function is set to something else than Input and referenced switches is empty
 		if (!function.IsSameAs(wxT("Input")) && m_switches.empty()) {
 			wxLogWarning("%s has function %s and should reference some switch(es) but doesn't! The function value will thus not be written to file!", getName(), getFunction());
-			::wxGetApp().m_frame->GetLogWindow()->Show(true);
+			SHOWLOGWINDOW;
 		}
 		if (defaultToEngaged)
 			outFile->AddLine(wxT("DefaultToEngaged=Y"));
@@ -98,7 +98,7 @@ void Drawstop::read(wxFileConfig *cfg, bool usingOldPanelFormat, Organ *readOrga
 					addSwitchReference(readOrgan->getOrganSwitchAt(swRefNbr - 1));
 				else {
 					wxLogWarning("Switch%0.3d (%s) is already added to %s! This additional switch entry will be ignored!", swRefNbr, readOrgan->getOrganSwitchAt(swRefNbr - 1)->getName(), getName());
-					::wxGetApp().m_frame->GetLogWindow()->Show(true);
+					SHOWLOGWINDOW;
 				}
 			}
 		}

--- a/src/GOODF.cpp
+++ b/src/GOODF.cpp
@@ -30,6 +30,9 @@
 IMPLEMENT_APP(GOODF)
 
 bool GOODF::OnInit() {
+	if (wxApp::argc > 1) {
+		fprintf(stderr, "arg[1]: %s\n", (const char *)(wxApp::argv[1].mb_str()));
+	}
 	// Create fullAppName with version from cmake
 	m_fullAppName = wxT("GoOdf ");
 	m_fullAppName.Append(wxT(GOODF_VERSION));

--- a/src/GOODFFrame.cpp
+++ b/src/GOODFFrame.cpp
@@ -811,7 +811,7 @@ void GOODFFrame::DoOpenOrgan(wxString filePath) {
 	m_organ->organElementHasChanged(true);
 	m_organTreeCtrl->SelectItem(tree_organ);
 	SetImportXfadeMenuItemState();
-	this->Raise();
+	// this->Raise();  should not be necessary
 }
 
 void GOODFFrame::OrganTreeChildItemLabelChanged(wxString label) {

--- a/src/GOODFFunctions.h
+++ b/src/GOODFFunctions.h
@@ -26,6 +26,12 @@
 #include <wx/filename.h>
 #include <vector>
 #include "GOODF.h"
+// macro to both show and raise the LogWindow
+#define SHOWLOGWINDOW do { \
+	wxLogWindow* w = ::wxGetApp().m_frame->GetLogWindow(); \
+	w->Show(true); \
+	w->GetFrame()->Raise(); \
+} while (0)
 
 class Organ;
 
@@ -62,7 +68,7 @@ namespace GOODF_functions {
 	inline wxString removeBaseOdfPath(wxString path) {
 		wxString stringToReturn = path;
 		wxFileName fName = wxFileName(path);
-		if (fName.FileExists()) {
+		if (fName.FileExists() && stringToReturn.StartsWith(wxFILE_SEP_PATH)) {
 			fName.MakeRelativeTo(::wxGetApp().m_frame->m_organ->getOdfRoot());
 			stringToReturn = fName.GetFullPath();
 			if (stringToReturn.StartsWith(wxFILE_SEP_PATH))
@@ -82,6 +88,8 @@ namespace GOODF_functions {
 			if (theFile.FileExists()) {
 				return theFile.GetFullPath();
 			}
+			wxLogWarning("%s does not exist.  Removed from .organ file", relativePath);
+			SHOWLOGWINDOW;
 		}
 		return wxEmptyString;
 	}

--- a/src/GoPanel.cpp
+++ b/src/GoPanel.cpp
@@ -100,7 +100,7 @@ void GoPanel::write(wxTextFile *outFile, unsigned panelNbr) {
 
 	if (panelNbr == 0 && nbGUIElements < 1) {
 		wxLogWarning("Nothing is displayed as a GUI Element on the main panel! Is this really intentional?");
-		::wxGetApp().m_frame->GetLogWindow()->Show(true);
+		SHOWLOGWINDOW;
 	}
 }
 

--- a/src/Organ.cpp
+++ b/src/Organ.cpp
@@ -172,7 +172,7 @@ void Organ::writeOrgan(wxTextFile *outFile) {
 	}
 	if (m_Windchestgroups.empty()) {
 		wxLogWarning("There are no windchestgroups in the organ! The .organ file won't be functional!");
-		::wxGetApp().m_frame->GetLogWindow()->Show(true);
+		SHOWLOGWINDOW;
 	}
 
 	// Couplers
@@ -223,7 +223,7 @@ void Organ::writeOrgan(wxTextFile *outFile) {
 	for (auto& sw : m_Switches) {
 		if (sw.getFunction().IsSameAs(wxT("Input")) && !isElementReferenced(&sw)) {
 			wxLogWarning("Switch %s has function Input but is not referenced anywhere.", sw.getName());
-			::wxGetApp().m_frame->GetLogWindow()->Show(true);
+			SHOWLOGWINDOW;
 		}
 		wxString switchId = wxT("[Switch") + GOODF_functions::number_format(i) + wxT("]");
 		outFile->AddLine(switchId);

--- a/src/OrganFileParser.cpp
+++ b/src/OrganFileParser.cpp
@@ -201,7 +201,7 @@ void OrganFileParser::parseOrganSection() {
 						m_organ->getOrganPanelAt(0)->addImage(img);
 					else {
 						wxLogWarning("%s is not possible to parse and use!", imgGroupName);
-						::wxGetApp().m_frame->GetLogWindow()->Show(true);
+						SHOWLOGWINDOW;
 					}
 				}
 			}
@@ -220,7 +220,7 @@ void OrganFileParser::parseOrganSection() {
 					createGUILabel(m_organ->getOrganPanelAt(0));
 				} else {
 					wxLogWarning("%s couldn't be found!", labelGroupName);
-					::wxGetApp().m_frame->GetLogWindow()->Show(true);
+					SHOWLOGWINDOW;
 				}
 			}
 			m_organFile->SetPath("/Organ");
@@ -253,7 +253,7 @@ void OrganFileParser::parseOrganSection() {
 				}
 			} else {
 				wxLogWarning("%s couldn't be found!", enclosureGroupName);
-				::wxGetApp().m_frame->GetLogWindow()->Show(true);
+				SHOWLOGWINDOW;
 			}
 		}
 		m_organFile->SetPath("/Organ");
@@ -277,7 +277,7 @@ void OrganFileParser::parseOrganSection() {
 				}
 			} else {
 				wxLogWarning("%s couldn't be found!", switchGroupName);
-				::wxGetApp().m_frame->GetLogWindow()->Show(true);
+				SHOWLOGWINDOW;
 			}
 		}
 		m_organFile->SetPath("/Organ");
@@ -301,7 +301,7 @@ void OrganFileParser::parseOrganSection() {
 				}
 			} else {
 				wxLogWarning("%s couldn't be found!", tremGroupName);
-				::wxGetApp().m_frame->GetLogWindow()->Show(true);
+				SHOWLOGWINDOW;
 			}
 		}
 		m_organFile->SetPath("/Organ");
@@ -321,14 +321,14 @@ void OrganFileParser::parseOrganSection() {
 				m_organ->addWindchestgroup(windchest);
 			} else {
 				wxLogWarning("%s couldn't be found!", windchestGroupName);
-				::wxGetApp().m_frame->GetLogWindow()->Show(true);
+				SHOWLOGWINDOW;
 			}
 		}
 		m_organFile->SetPath("/Organ");
 	}
 	if (nbrWindchests == 0) {
 		wxLogWarning("There are no windchestgroups in the organ! The .organ file won't be functional until at least one windchestgroup exist!");
-		::wxGetApp().m_frame->GetLogWindow()->Show(true);
+		SHOWLOGWINDOW;
 	}
 
 	// parse ranks
@@ -351,13 +351,13 @@ void OrganFileParser::parseOrganSection() {
 						rankUsesLegacyXfades = true;
 					}
 					if (rankUsesLegacyXfades) {
-						::wxGetApp().m_frame->GetLogWindow()->Show(true);
+						SHOWLOGWINDOW;
 						break;
 					}
 				}
 			} else {
 				wxLogWarning("%s couldn't be found!", rankGroupName);
-				::wxGetApp().m_frame->GetLogWindow()->Show(true);
+				SHOWLOGWINDOW;
 			}
 		}
 		m_organFile->SetPath("/Organ");
@@ -394,7 +394,7 @@ void OrganFileParser::parseOrganSection() {
 				}
 			} else {
 				wxLogWarning("%s couldn't be found!", manGroupName);
-				::wxGetApp().m_frame->GetLogWindow()->Show(true);
+				SHOWLOGWINDOW;
 			}
 		}
 
@@ -446,7 +446,7 @@ void OrganFileParser::parseOrganSection() {
 				}
 			} else {
 				wxLogWarning("%s couldn't be found!", pistonGroupName);
-				::wxGetApp().m_frame->GetLogWindow()->Show(true);
+				SHOWLOGWINDOW;
 			}
 		}
 		m_organFile->SetPath("/Organ");
@@ -470,7 +470,7 @@ void OrganFileParser::parseOrganSection() {
 				}
 			} else {
 				wxLogWarning("%s couldn't be found!", divCplrGroupName);
-				::wxGetApp().m_frame->GetLogWindow()->Show(true);
+				SHOWLOGWINDOW;
 			}
 		}
 		m_organFile->SetPath("/Organ");
@@ -494,7 +494,7 @@ void OrganFileParser::parseOrganSection() {
 				}
 			} else {
 				wxLogWarning("%s couldn't be found!", generalGroupName);
-				::wxGetApp().m_frame->GetLogWindow()->Show(true);
+				SHOWLOGWINDOW;
 			}
 		}
 		m_organFile->SetPath("/Organ");
@@ -517,7 +517,7 @@ void OrganFileParser::parseOrganSection() {
 					}
 				} else {
 					wxLogWarning("%s couldn't be found!", setterGroupName);
-					::wxGetApp().m_frame->GetLogWindow()->Show(true);
+					SHOWLOGWINDOW;
 				}
 			}
 		}
@@ -548,7 +548,7 @@ void OrganFileParser::parseOrganSection() {
 				parsePanelElements(m_organ->getOrganPanelAt(m_organ->getNumberOfPanels() - 1), panelGroupName);
 			} else {
 				wxLogWarning("%s couldn't be found!", panelGroupName);
-				::wxGetApp().m_frame->GetLogWindow()->Show(true);
+				SHOWLOGWINDOW;
 			}
 		}
 		m_organFile->SetPath("/Organ");
@@ -876,13 +876,13 @@ void OrganFileParser::parsePanelElements(GoPanel *targetPanel, wxString panelId)
 					}
 				} else {
 					wxLogWarning("%s%s couldn't be found!", panelId, elementGroupName);
-					::wxGetApp().m_frame->GetLogWindow()->Show(true);
+					SHOWLOGWINDOW;
 				}
 			}
 			m_organFile->SetPath(wxT("/") + panelId);
 		} else {
 			wxLogWarning("NumberOfGUIElements=%d is invalid in %s!", nbrGuiElements, panelId);
-			::wxGetApp().m_frame->GetLogWindow()->Show(true);
+			SHOWLOGWINDOW;
 		}
 	} else {
 		// old style panel elements are read in another way, but they will be converted to the new style

--- a/src/Pipe.cpp
+++ b/src/Pipe.cpp
@@ -239,7 +239,7 @@ void Pipe::read(wxFileConfig *cfg, wxString pipeNr, Rank *parent, Organ *readOrg
 			wxLogWarning("Separate releases found in %s %s that is percussive! Ignoring them.", parent->getName(), pipeNr);
 		else
 			wxLogWarning("Separate release found in %s %s that is percussive! Ignoring it.", parent->getName(), pipeNr);
-		::wxGetApp().m_frame->GetLogWindow()->Show(true);
+		SHOWLOGWINDOW;
 	}
 
 	// finally a sanity check to see that there is at least one valid attack in the pipe
@@ -249,7 +249,7 @@ void Pipe::read(wxFileConfig *cfg, wxString pipeNr, Rank *parent, Organ *readOrg
 		a.fullPath = wxT("DUMMY");
 		m_attacks.push_back(a);
 		wxLogWarning("No valid pipe could be added for %s %s! Setting it to DUMMY.", parent->getName(), pipeNr);
-		::wxGetApp().m_frame->GetLogWindow()->Show(true);
+		SHOWLOGWINDOW;
 	} else {
 		// update the pipes root path of parent rank from the main attack
 		wxFileName fileName = m_attacks.front().fullPath;


### PR DESCRIPTION
I've been very happily using GoOdf to quicky create .organ files to test problems with the recent GrandOrgue release.  Thanks @larspalo for this great program!

I experienced a few unexpected "gotchas" (for me at least!) while investigating https://github.com/GrandOrgue/grandorgue/issues/2004#issuecomment-2483899017

FWIW: I use a non-tiling window manager (cwm) that does not display window frames, etc.

* Raise() the LogWindow after calling Show().  Otherwise the log window might be obscured and the messages missed. Define a SHOWLOGWINDOW macro to wrap this.
* It is (probably) not necessary to raise the main window.  This might also obscure the log window. 
* Only call MakeRelativeTo() if we have an absolute path. removeBaseOdfPath() may not need to calculate a relative path if the filename does not start with a path separator.
* Log any files that cannot be found when reading a .organ file and mention that they will be excluded/deleted.
* When adding a Wave tremulant and only a single ignore Wave tremulant attack exists, set that attack to play when Wave tremulant is off. Log if this has been done.  This behaviour is enabled when the bool setSingle is true (the default).