### PR TITLE
raise the log window after file load/save

### DIFF
--- a/src/GOODFFrame.cpp
+++ b/src/GOODFFrame.cpp
@@ -688,6 +688,8 @@ void GOODFFrame::OnWriteODF(wxCommandEvent& WXUNUSED(event)) {
 	m_organ->setModified(false);
 	UpdateFrameTitle();
 	m_recentlyUsed->AddFileToHistory(fullFileName);
+	if (m_logWindow->GetFrame()->IsShown())
+		m_logWindow->GetFrame()->Raise();
 }
 
 void GOODFFrame::OnReadOrganFile(wxCommandEvent& WXUNUSED(event)) {
@@ -813,6 +815,8 @@ void GOODFFrame::DoOpenOrgan(wxString filePath) {
 	m_organTreeCtrl->SelectItem(tree_organ);
 	SetImportXfadeMenuItemState();
 	this->Raise();
+	if (m_logWindow->GetFrame()->IsShown())
+		m_logWindow->GetFrame()->Raise();
 }
 
 void GOODFFrame::OrganTreeChildItemLabelChanged(wxString label) {


### PR DESCRIPTION
The log window might be obscured on some platforms.  Raising it on file load/save can be useful.  I'm always forgetting to add ranks to windchests...

This is part of 109.