### PR TITLE
replace exist with exists in messages that have a singular subject

### DIFF
--- a/src/GOODFFrame.cpp
+++ b/src/GOODFFrame.cpp
@@ -664,7 +664,7 @@ void GOODFFrame::OnWriteODF(wxCommandEvent& WXUNUSED(event)) {
 	wxString fullFileName = m_organPanel->getOdfPath() + wxFILE_SEP_PATH + m_organPanel->getOdfName() + wxT(".organ");
 	wxTextFile *odfFile = new wxTextFile(fullFileName);
 	if (odfFile->Exists() && !m_organHasBeenSaved) {
-		wxMessageDialog dlg(this, wxT("ODF file already exist. Do you want to overwrite it?"), wxT("Existing ODF file"), wxYES_NO|wxCENTRE|wxICON_EXCLAMATION);
+		wxMessageDialog dlg(this, wxT("ODF file already exists. Do you want to overwrite it?"), wxT("Existing ODF file"), wxYES_NO|wxCENTRE|wxICON_EXCLAMATION);
 		if (dlg.ShowModal() == wxID_YES) {
 			odfFile->Open(fullFileName);
 			odfFile->Clear();

--- a/src/OrganFileParser.cpp
+++ b/src/OrganFileParser.cpp
@@ -327,7 +327,7 @@ void OrganFileParser::parseOrganSection() {
 		m_organFile->SetPath("/Organ");
 	}
 	if (nbrWindchests == 0) {
-		wxLogWarning("There are no windchestgroups in the organ! The .organ file won't be functional until at least one windchestgroup exist!");
+		wxLogWarning("There are no windchestgroups in the organ! The .organ file won't be functional until at least one windchestgroup exists!");
 		::wxGetApp().m_frame->GetLogWindow()->Show(true);
 	}
 


### PR DESCRIPTION
For some reason I get these message dialogs a lot!  In these cases "exist" should be "exists" to prevent awkward sounding messages.  (To a native English speaker.)

An ODF file exists.  Many ODF files exist.
