### PR TITLE
fix crash on some platforms when a corrupt ODF is read

### DIFF
--- a/src/OrganFileParser.cpp
+++ b/src/OrganFileParser.cpp
@@ -39,6 +39,7 @@ OrganFileParser::OrganFileParser(wxString filePath, Organ *organ) {
 	m_organIsReady = false;
 	m_isUsingOldPanelFormat = false;
 	m_errorMessage = wxEmptyString;
+	m_progressDlg = NULL;
 
 	readIniFile();
 	if (m_fileIsOk) {


### PR DESCRIPTION
On some platforms (FreeBSD in particular) GoOdf will crash if a corrupt .organ file is opened.

**m_progressDlg**  is used without being initialized if **m_fileIsOk** is false.
