### PR TITLE
display the file output dialogs if the output file name has changed

### DIFF
--- a/src/GOODFFrame.cpp
+++ b/src/GOODFFrame.cpp
@@ -662,6 +662,9 @@ void GOODFFrame::OnWriteODF(wxCommandEvent& WXUNUSED(event)) {
 		return;
 	}
 	wxString fullFileName = m_organPanel->getOdfPath() + wxFILE_SEP_PATH + m_organPanel->getOdfName() + wxT(".organ");
+	if (m_recentlyUsed->GetCount() &&  !fullFileName.IsSameAs(m_recentlyUsed->GetHistoryFile(0))) {
+		m_organHasBeenSaved = false;
+	}
 	wxTextFile *odfFile = new wxTextFile(fullFileName);
 	if (odfFile->Exists() && !m_organHasBeenSaved) {
 		wxMessageDialog dlg(this, wxT("ODF file already exist. Do you want to overwrite it?"), wxT("Existing ODF file"), wxYES_NO|wxCENTRE|wxICON_EXCLAMATION);


### PR DESCRIPTION
It would be useful to re-enable the file checks flagged by **m_organHasBeenSaved** if  the name of the .organ file has been changed in the "_Name of .organ file (without the extension):_" field.

I will often read an ODF and write out copies to different names.  There's no guarantee that the file doesn't already exist and a warning that I'm about to overwrite an existing file would be helpful.
