### PR TITLE
present dialogs if the output file cannot be saved

### DIFF
--- a/src/GOODFFrame.cpp
+++ b/src/GOODFFrame.cpp
@@ -663,6 +663,11 @@ void GOODFFrame::OnWriteODF(wxCommandEvent& WXUNUSED(event)) {
 	}
 	wxString fullFileName = m_organPanel->getOdfPath() + wxFILE_SEP_PATH + m_organPanel->getOdfName() + wxT(".organ");
 	wxTextFile *odfFile = new wxTextFile(fullFileName);
+	if (odfFile->Exists() && !wxFileName::IsFileWritable(fullFileName)) {
+		wxMessageDialog msg(this, wxT("ODF file ") + m_organPanel->getOdfName() + wxT(".organ not writable!"), wxT("ODF file not writable!"), wxOK|wxCENTRE);
+		msg.ShowModal();
+		return;
+	}
 	if (odfFile->Exists() && !m_organHasBeenSaved) {
 		wxMessageDialog dlg(this, wxT("ODF file already exist. Do you want to overwrite it?"), wxT("Existing ODF file"), wxYES_NO|wxCENTRE|wxICON_EXCLAMATION);
 		if (dlg.ShowModal() == wxID_YES) {
@@ -672,8 +677,13 @@ void GOODFFrame::OnWriteODF(wxCommandEvent& WXUNUSED(event)) {
 			delete odfFile;
 			return;
 		}
-	} else {
-		odfFile->Create(fullFileName);
+	} else if (!odfFile->Exists()) {
+		if (!odfFile->Create(fullFileName)) {
+			wxMessageDialog msg(this, wxT("ODF file ") + m_organPanel->getOdfName() + wxT(".organ failed to create!"), wxT("ODF file not created!"), wxOK|wxCENTRE);
+			msg.ShowModal();
+			return;
+		}
+
 	}
 	m_organ->writeOrgan(odfFile);
 


### PR DESCRIPTION
GoOdf currently assumes that the write succeeds.

Could be useful to add some checks for "_is it writeable?_", "_can I create it?_"
